### PR TITLE
Tri 50 FCM token 저장 & 삭제 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ###
 *.env
+
+### Firebase Admin SDK ###
+catchping-fcmserver-firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+
+	// firebase-admin
+	implementation 'com.google.firebase:firebase-admin:9.4.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/trinity/ctc/config/FirebaseInitializer.java
+++ b/src/main/java/com/trinity/ctc/config/FirebaseInitializer.java
@@ -1,0 +1,43 @@
+package com.trinity.ctc.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.trinity.ctc.util.exception.CustomException;
+import com.trinity.ctc.util.exception.error_code.FirebaseErrorCode;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Component
+public class FirebaseInitializer {
+
+    @Value("${firebase.key-path}")
+    private String fcmKeyPath;
+
+    @PostConstruct
+    public void initialize() {
+        try (InputStream serviceAccount = new ClassPathResource(fcmKeyPath).getInputStream()) {
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .build();
+
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase initialized successfully.");
+            } else {
+                log.info("Firebase already initialized.");
+            }
+
+        } catch (IOException e) {
+            throw new CustomException(FirebaseErrorCode.FIREBASE_INITIALIZATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/trinity/ctc/config/SwaggerConfig.java
+++ b/src/main/java/com/trinity/ctc/config/SwaggerConfig.java
@@ -28,6 +28,9 @@ public class SwaggerConfig {
     @Value("${swagger.group.seat.paths}")
     private String[] seatPaths;
 
+    @Value("${swagger.group.fcm.paths}")
+    private String[] fcmPaths;
+
     @Bean
     public OpenAPI customOpenAPI() {
         List<Server> servers = new ArrayList<>();
@@ -60,6 +63,17 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
                 .group("Seat API")
                 .pathsToMatch(seatPaths)
+                .build();
+    }
+
+    /**
+     *  Fcm API 그룹
+     */
+    @Bean
+    public GroupedOpenApi FcmOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("Fcm API")
+                .pathsToMatch(fcmPaths)
                 .build();
     }
 }

--- a/src/main/java/com/trinity/ctc/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/controller/FcmController.java
@@ -1,0 +1,35 @@
+package com.trinity.ctc.domain.fcm.controller;
+
+import com.trinity.ctc.domain.fcm.dto.FcmTokenRequest;
+import com.trinity.ctc.domain.fcm.service.FcmService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcmTokens")
+public class FcmController {
+    private final FcmService fcmService;
+
+    @PostMapping("/renew")
+    @Operation(
+            summary = "fcm 토큰 갱신",
+            description = "로그인 세션이 유지되는 동안 브라우저 재접속 시, fcm 토큰 정보 갱신 요청"
+    )
+    @ApiResponse(
+            responseCode = "204",
+            description = "성공"
+    )
+    public ResponseEntity<Void> renewFcmToken(@RequestBody FcmTokenRequest fcmTokenRequest) {
+        fcmService.renewFcmToken(fcmTokenRequest);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/trinity/ctc/domain/fcm/dto/FcmTokenRequest.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/dto/FcmTokenRequest.java
@@ -1,0 +1,17 @@
+package com.trinity.ctc.domain.fcm.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "FCM 토큰 정보")
+public class FcmTokenRequest {
+    @NotNull
+    @Schema(description = "FCM 토큰 값", example = "eFWf9agIX28I7RXM3Zy5_G:APA91bGuCc3Do-SZVanV7C39JH465yTDL...")
+    private String fcmToken;
+
+    @Schema(description = "토큰 발급 시간 (optional, 밀리초 단위의 timestamp, 로그아웃 요청 시 불필요)",
+            example = "1739711637642")
+    private Long timestamp;
+}

--- a/src/main/java/com/trinity/ctc/domain/fcm/entity/Fcm.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/entity/Fcm.java
@@ -2,14 +2,16 @@ package com.trinity.ctc.domain.fcm.entity;
 
 import com.trinity.ctc.domain.user.entity.User;
 import jakarta.persistence.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.Date;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Fcm {
 
     @Id
@@ -18,17 +20,19 @@ public class Fcm {
     private Long id;
 
     private String token;
-
-    @CreatedDate
-    private Date createdAt;
-
-    @LastModifiedDate
+    private Date registeredAt;
     private Date updatedAt;
-
     private Date expiresAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id")
     private User user;
 
+    @Builder
+    public Fcm(String token, Date registeredAt, Date expiresAt, User user){
+        this.token = token;
+        this.registeredAt = registeredAt;
+        this.expiresAt = expiresAt;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/fcm/entity/Fcm.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/entity/Fcm.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -20,16 +20,16 @@ public class Fcm {
     private Long id;
 
     private String token;
-    private Date registeredAt;
-    private Date updatedAt;
-    private Date expiresAt;
+    private LocalDateTime registeredAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime expiresAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id")
     private User user;
 
     @Builder
-    public Fcm(String token, Date registeredAt, Date expiresAt, User user){
+    public Fcm(String token, LocalDateTime registeredAt, LocalDateTime expiresAt, User user){
         this.token = token;
         this.registeredAt = registeredAt;
         this.expiresAt = expiresAt;

--- a/src/main/java/com/trinity/ctc/domain/fcm/repository/FcmRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/repository/FcmRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public interface FcmRepository extends JpaRepository<Fcm, Long> {
@@ -19,5 +20,7 @@ public interface FcmRepository extends JpaRepository<Fcm, Long> {
     @Transactional
     @Modifying
     @Query("UPDATE Fcm f SET f.updatedAt = :updatedAt, f.expiresAt = :expiresAt WHERE f.token = :token")
-    void updateToken(@Param("token") String token, @Param("updatedAt") Date updatedAt, @Param("expiresAt") Date expiresAt);
+    void updateToken(@Param("token") String token,
+                     @Param("updatedAt") LocalDateTime updatedAt,
+                     @Param("expiresAt") LocalDateTime expiresAt);
 }

--- a/src/main/java/com/trinity/ctc/domain/fcm/repository/FcmRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/repository/FcmRepository.java
@@ -1,0 +1,23 @@
+package com.trinity.ctc.domain.fcm.repository;
+
+import com.trinity.ctc.domain.fcm.entity.Fcm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+public interface FcmRepository extends JpaRepository<Fcm, Long> {
+    @Transactional
+    void deleteByToken(String token);
+
+    @Transactional
+    void deleteByExpiresAtBefore(Date currentDate);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Fcm f SET f.updatedAt = :updatedAt, f.expiresAt = :expiresAt WHERE f.token = :token")
+    void updateToken(@Param("token") String token, @Param("updatedAt") Date updatedAt, @Param("expiresAt") Date expiresAt);
+}

--- a/src/main/java/com/trinity/ctc/domain/fcm/service/FcmService.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/service/FcmService.java
@@ -7,12 +7,13 @@ import com.trinity.ctc.domain.user.entity.User;
 import com.trinity.ctc.kakao.repository.UserRepository;
 import com.trinity.ctc.util.exception.CustomException;
 import com.trinity.ctc.util.exception.error_code.UserErrorCode;
+import com.trinity.ctc.util.formatter.DateTimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Service
@@ -30,9 +31,9 @@ public class FcmService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
 
-        Long oneMonth = Duration.ofDays(30).toMillis();
-        Date registeredAt = new Date(fcmTokenRequest.getTimestamp());
-        Date expiresAt = new Date(fcmTokenRequest.getTimestamp() + oneMonth);
+        LocalDateTime registeredAt = DateTimeUtil.convertMillisToLocalDateTime(fcmTokenRequest.getTimestamp());
+        LocalDateTime expiresAt = registeredAt.plusDays(30);
+        ;
 
         Fcm fcm = Fcm.builder()
                 .token(fcmTokenRequest.getFcmToken())
@@ -56,9 +57,9 @@ public class FcmService {
      */
     public void renewFcmToken(FcmTokenRequest fcmTokenRequest) {
         String fcmToken = fcmTokenRequest.getFcmToken();
-        Long oneMonth = Duration.ofDays(30).toMillis();
-        Date updatedAt = new Date(fcmTokenRequest.getTimestamp());
-        Date expiresAt = new Date(fcmTokenRequest.getTimestamp() + oneMonth);
+        LocalDateTime updatedAt = DateTimeUtil.convertMillisToLocalDateTime(fcmTokenRequest.getTimestamp());
+        LocalDateTime expiresAt = updatedAt.plusDays(30);
+        ;
 
         fcmRepository.updateToken(fcmToken, updatedAt, expiresAt);
     }

--- a/src/main/java/com/trinity/ctc/domain/fcm/service/FcmService.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/service/FcmService.java
@@ -1,0 +1,74 @@
+package com.trinity.ctc.domain.fcm.service;
+
+import com.trinity.ctc.domain.fcm.dto.FcmTokenRequest;
+import com.trinity.ctc.domain.fcm.entity.Fcm;
+import com.trinity.ctc.domain.fcm.repository.FcmRepository;
+import com.trinity.ctc.domain.user.entity.User;
+import com.trinity.ctc.kakao.repository.UserRepository;
+import com.trinity.ctc.util.exception.CustomException;
+import com.trinity.ctc.util.exception.error_code.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmService {
+    public final FcmRepository fcmRepository;
+    public final UserRepository userRepository;
+
+    /**
+     * 로그인 시, 해당 기기에 대한 사용자의 fcm 토큰 정보 초기화
+     */
+    public void registerFcmToken(FcmTokenRequest fcmTokenRequest, Long userId) {
+        // 유저 entity
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
+
+        Long oneMonth = Duration.ofDays(30).toMillis();
+        Date registeredAt = new Date(fcmTokenRequest.getTimestamp());
+        Date expiresAt = new Date(fcmTokenRequest.getTimestamp() + oneMonth);
+
+        Fcm fcm = Fcm.builder()
+                .token(fcmTokenRequest.getFcmToken())
+                .registeredAt(registeredAt)
+                .expiresAt(expiresAt)
+                .user(user)
+                .build();
+
+        fcmRepository.save(fcm);
+    }
+
+    /**
+     * 로그아웃 시, 해당 기기에 대한 사용자의 fcm 토큰 정보 삭제
+     */
+    public void deleteFcmToken(FcmTokenRequest fcmTokenRequest) {
+        fcmRepository.deleteByToken(fcmTokenRequest.getFcmToken());
+    }
+
+    /**
+     * 로그인 세션이 유지된 상태에서 접속 시, fcm 토큰 만료 기간 갱신
+     */
+    public void renewFcmToken(FcmTokenRequest fcmTokenRequest) {
+        String fcmToken = fcmTokenRequest.getFcmToken();
+        Long oneMonth = Duration.ofDays(30).toMillis();
+        Date updatedAt = new Date(fcmTokenRequest.getTimestamp());
+        Date expiresAt = new Date(fcmTokenRequest.getTimestamp() + oneMonth);
+
+        fcmRepository.updateToken(fcmToken, updatedAt, expiresAt);
+    }
+
+    /**
+     * 매일 자정에 만료된 fcm 토큰 삭제 (스케줄링)
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void expireFcmToken() {
+        Date currentDate = new Date();
+        fcmRepository.deleteByExpiresAtBefore(currentDate);
+    }
+}

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/NotificationHistory.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/NotificationHistory.java
@@ -1,9 +1,9 @@
 package com.trinity.ctc.domain.notification.entity;
 
+import com.trinity.ctc.domain.notification.entity.errorCode.FcmErrorCode;
 import com.trinity.ctc.domain.notification.entity.type.NotificationType;
 import com.trinity.ctc.domain.user.entity.User;
 import jakarta.persistence.*;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -20,10 +20,12 @@ public class NotificationHistory {
     @Enumerated(EnumType.STRING)
     private NotificationType type;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
+    private String message;
+    private LocalDateTime sentAt;
+    private Boolean isSent = false;
 
-    private LocalDateTime sendingAt;
+    @Enumerated(EnumType.STRING)
+    private FcmErrorCode errorCode;
 
     private Boolean isDeleted = false;
 

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/ReservationNotification.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/ReservationNotification.java
@@ -1,5 +1,6 @@
 package com.trinity.ctc.domain.notification.entity;
 
+import com.trinity.ctc.domain.notification.entity.type.NotificationType;
 import com.trinity.ctc.domain.reservation.entity.Reservation;
 import com.trinity.ctc.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -13,6 +14,12 @@ public class ReservationNotification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    private String title;
+    private String body;
+    private Long date;
     private LocalDateTime scheduledTime;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/SeatNotification.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/SeatNotification.java
@@ -1,11 +1,10 @@
 package com.trinity.ctc.domain.notification.entity;
 
-import com.trinity.ctc.domain.seat.entity.SeatAvailability;
 import com.trinity.ctc.domain.user.entity.User;
 import jakarta.persistence.*;
 
 @Entity
-public class AvailableSeatNotification {
+public class SeatNotification {
 
     @Id
     @Column
@@ -17,6 +16,6 @@ public class AvailableSeatNotification {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seat_availability_id")
-    private SeatAvailability seatAvailability;
+    @JoinColumn(name = "seat_notification_message_id")
+    private SeatNotificationMessage seatNotificationMessage;
 }

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/SeatNotificationMessage.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/SeatNotificationMessage.java
@@ -1,0 +1,26 @@
+package com.trinity.ctc.domain.notification.entity;
+
+import com.trinity.ctc.domain.seat.entity.SeatAvailability;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class SeatNotificationMessage {
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String title;
+    private String body;
+    private Long date;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_availability_id")
+    private SeatAvailability seatAvailability;
+
+    @OneToMany(mappedBy = "seat_notification_message")
+    private List<SeatNotification> seatNotificationList = new ArrayList<>();
+}

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/SeatNotificationMessage.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/SeatNotificationMessage.java
@@ -21,6 +21,6 @@ public class SeatNotificationMessage {
     @JoinColumn(name = "seat_availability_id")
     private SeatAvailability seatAvailability;
 
-    @OneToMany(mappedBy = "seat_notification_message")
+    @OneToMany(mappedBy = "seatNotificationMessage")
     private List<SeatNotification> seatNotificationList = new ArrayList<>();
 }

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/errorCode/FcmErrorCode.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/errorCode/FcmErrorCode.java
@@ -1,0 +1,5 @@
+package com.trinity.ctc.domain.notification.entity.errorCode;
+
+public enum FcmErrorCode {
+    NotRegistered, InvalidRegistration, MismatchSenderId, MessageTooBig
+}

--- a/src/main/java/com/trinity/ctc/domain/notification/entity/type/NotificationType.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/entity/type/NotificationType.java
@@ -1,15 +1,10 @@
 package com.trinity.ctc.domain.notification.entity.type;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum NotificationType {
-    EMPTY_NOTIFICATION(1, "신청하신 자리에 자리가 났습니다."),
-    DAILY_NOTIFICATION(2, "오늘 식당 예약하셨습니다."),
-    BEFORE_ONE_HOUR_NOTIFICATION(3, "한 시간 뒤, 예약있습니다.");
-
-    private final int code;
-    private final String message;
+    EMPTY_NOTIFICATION,
+    DAILY_NOTIFICATION,
+    BEFORE_ONE_HOUR_NOTIFICATION
 }

--- a/src/main/java/com/trinity/ctc/domain/user/entity/User.java
+++ b/src/main/java/com/trinity/ctc/domain/user/entity/User.java
@@ -12,11 +12,15 @@ import jakarta.persistence.*;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id

--- a/src/main/java/com/trinity/ctc/kakao/controller/AuthController.java
+++ b/src/main/java/com/trinity/ctc/kakao/controller/AuthController.java
@@ -1,39 +1,44 @@
 package com.trinity.ctc.kakao.controller;
 
+import com.trinity.ctc.domain.fcm.dto.FcmTokenRequest;
+import com.trinity.ctc.domain.fcm.service.FcmService;
 import com.trinity.ctc.kakao.dto.KakaoLogoutResponse;
 import com.trinity.ctc.kakao.dto.UserLoginResponse;
 import com.trinity.ctc.kakao.service.AuthService;
-import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
+@Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/users/kakao")
 public class AuthController {
 
     private final AuthService authService;
+    private final FcmService fcmService;
 
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
-
-    @GetMapping("/login")
-    public ResponseEntity<?> kakaoLogin(@RequestParam String code) {
+    @PostMapping("/login")
+    public ResponseEntity<?> kakaoLogin(@RequestParam String code, @RequestBody FcmTokenRequest fcmTokenRequest) {
         UserLoginResponse response = authService.authenticateWithKakao(code);
+
+        fcmService.registerFcmToken(fcmTokenRequest, response.getId());
+
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Map<String, String>> kakaoLogout(@RequestHeader("Authorization") String authorizationHeader) {
+    public ResponseEntity<Map<String, String>> kakaoLogout(@RequestHeader("Authorization") String authorizationHeader, @RequestBody FcmTokenRequest fcmTokenRequest) {
         String accessToken = authorizationHeader.replace("Bearer ", "").trim();
         KakaoLogoutResponse logoutResponse = authService.logout(accessToken);
-       return ResponseEntity.ok(Map.of(
-        "status", "success",
-        "id", logoutResponse.getId()));
+
+        fcmService.deleteFcmToken(fcmTokenRequest);
+
+        return ResponseEntity.ok(Map.of(
+                "status", "success",
+                "id", logoutResponse.getId()));
     }
 }

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/FcmTokenErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/FcmTokenErrorCode.java
@@ -1,0 +1,14 @@
+package com.trinity.ctc.util.exception.error_code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FcmTokenErrorCode implements ErrorCode {
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 FCM 토큰이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/FirebaseErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/FirebaseErrorCode.java
@@ -1,0 +1,14 @@
+package com.trinity.ctc.util.exception.error_code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FirebaseErrorCode implements ErrorCode {
+    FIREBASE_INITIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 초기화에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/trinity/ctc/util/formatter/DateTimeUtil.java
+++ b/src/main/java/com/trinity/ctc/util/formatter/DateTimeUtil.java
@@ -2,9 +2,7 @@ package com.trinity.ctc.util.formatter;
 
 import com.trinity.ctc.util.validator.DateTimeValidator;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 
 public class DateTimeUtil {
@@ -58,6 +56,13 @@ public class DateTimeUtil {
     public static LocalTime getOneHourLater(LocalDateTime dateTime) {
         LocalDateTime oneHourLater = dateTime.plusHours(1);
         return oneHourLater.toLocalTime();
+    }
+
+    // Long -> LocalDateTime 컨버트
+    public static LocalDateTime convertMillisToLocalDateTime(long timestamp) {
+        return Instant.ofEpochMilli(timestamp)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
     }
 
     // LocalDate -> LocalDateTime 컨버트

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,5 +40,10 @@ springdoc:
     path: /api-docs # OpenAPI 명세 기본 경로
   swagger-ui:
     path: /swagger-ui.html # Swagger UI 기본 경로
+---
+firebase:
+  project-id: catchping-fcmserver
+  key-path: catchping-fcmserver-firebase-adminsdk.json
+
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,8 @@ swagger:
       paths: /api/auth/**
     seat:
       paths: /api/seats/**
+    fcm:
+      paths: /api/fcmTokens/**
 springdoc:
   api-docs:
     path: /api-docs # OpenAPI 명세 기본 경로


### PR DESCRIPTION
# ☝️Issue Number
- #8 

# 🔎 Key Changes
- Firebase 세팅 및 초기화
- FCM 토큰 관리(저장/삭제/갱신/만료) 기능 구현
- 알림 관련 entity 추가 및 수정
> Entity 변경 사항
SeatNotificationMessage(추가)
AvailableSeatNotification -> SeatNotification(수정)
NotificationHistory(수정)
ReservationNotification(수정)

# 💌 To Reviewers
- Firebase admin SDK.json 파일을 추가해줘야 합니다. -> https://www.notion.so/FCM-198ea615225080b7a23cf4cb673ba5df
- 알림 관련 entity에 데이터 타입이나 칼럼이 수정된 부분이 많아 table을 drop 후 다시 실행해주세요!
