### PR TITLE
Tri 60 preoccupy

### DIFF
--- a/src/main/java/com/trinity/ctc/config/SwaggerConfig.java
+++ b/src/main/java/com/trinity/ctc/config/SwaggerConfig.java
@@ -28,6 +28,9 @@ public class SwaggerConfig {
     @Value("${swagger.group.seat.paths}")
     private String[] seatPaths;
 
+    @Value("/api/reservations/**")
+    private String[] reservationPaths;
+
     @Bean
     public OpenAPI customOpenAPI() {
         List<Server> servers = new ArrayList<>();
@@ -60,6 +63,17 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
                 .group("Seat API")
                 .pathsToMatch(seatPaths)
+                .build();
+    }
+
+    /**
+     * Seat API 그룹
+     */
+    @Bean
+    public GroupedOpenApi reservationOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("Reservation API")
+                .pathsToMatch(reservationPaths)
                 .build();
     }
 }

--- a/src/main/java/com/trinity/ctc/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/controller/ReservationController.java
@@ -1,9 +1,43 @@
 package com.trinity.ctc.domain.reservation.controller;
 
+import com.trinity.ctc.domain.reservation.dto.PreoccupyResponse;
+import com.trinity.ctc.domain.reservation.dto.ReservationRequest;
+import com.trinity.ctc.domain.reservation.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/reservations")
+@RequestMapping("/api/reservations")
+@RequiredArgsConstructor
+@Tag(name = "Reservation", description = "예약관련 API")
 public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping("/preoccupy")
+    @Operation(
+            summary = "예약선점 기능",
+            description = "예약하기 전, 예약정보 기반으로 예약자리를 선점하는 기능"
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "예약선점 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PreoccupyResponse.class)
+            )
+    )
+    public ResponseEntity<PreoccupyResponse> preoccupySeat(@RequestBody ReservationRequest reservationRequest) {
+        PreoccupyResponse result = reservationService.occupyInAdvance(reservationRequest);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/reservation/dto/PreoccupyResponse.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/dto/PreoccupyResponse.java
@@ -13,7 +13,11 @@ public class PreoccupyResponse {
     @Schema(description = "요청 성공 여부", example = "true")
     private boolean isSuccess;
 
-    public static PreoccupyResponse of(boolean isSuccess) {
-        return new PreoccupyResponse(isSuccess);
+    @Schema(description = "생성된 예약정보 ID", example = "1")
+    private long reservationId;
+
+
+    public static PreoccupyResponse of(boolean isSuccess, long reservationId) {
+        return new PreoccupyResponse(isSuccess, reservationId);
     }
 }

--- a/src/main/java/com/trinity/ctc/domain/reservation/dto/PreoccupyResponse.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/dto/PreoccupyResponse.java
@@ -1,0 +1,19 @@
+package com.trinity.ctc.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Schema
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PreoccupyResponse {
+
+    @Schema(description = "요청 성공 여부", example = "true")
+    private boolean isSuccess;
+
+    public static PreoccupyResponse of(boolean isSuccess) {
+        return new PreoccupyResponse(isSuccess);
+    }
+}

--- a/src/main/java/com/trinity/ctc/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/dto/ReservationRequest.java
@@ -1,0 +1,29 @@
+package com.trinity.ctc.domain.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class ReservationRequest {
+
+    @Schema(description = "예약자 ID", example = "1")
+    private long userId;
+
+    @Schema(description = "대상 식당 ID", example = "2")
+    private long restaurantId;
+
+    @Schema(description = "좌석타입 ID", example = "1")
+    private long seatTypeId;
+
+    @Schema(description = "선택한 예약일 (yyyy-MM-dd)", example = "2025-02-15")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate selectedDate;
+
+    @Schema(description = "예약시간 타입슬롯 (HH:mm)", example = "09:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime reservationTime;
+}

--- a/src/main/java/com/trinity/ctc/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/entity/Reservation.java
@@ -5,14 +5,20 @@ import com.trinity.ctc.domain.restaurant.entity.Restaurant;
 import com.trinity.ctc.domain.seat.entity.SeatType;
 import com.trinity.ctc.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation {
 
     @Id
@@ -23,7 +29,8 @@ public class Reservation {
     private LocalDate reservationDate;
 
     @CreatedDate
-    private LocalDateTime created_at;
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
@@ -43,4 +50,14 @@ public class Reservation {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seat_type_id")
     private SeatType seatType;
+
+    @Builder
+    public Reservation(LocalDate reservationDate, ReservationStatus status, Restaurant restaurant, User user, ReservationTime reservationTime ,SeatType seatType) {
+        this.reservationDate = reservationDate;
+        this.status = status;
+        this.restaurant = restaurant;
+        this.user = user;
+        this.reservationTime = reservationTime;
+        this.seatType = seatType;
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package com.trinity.ctc.domain.reservation.repository;
+
+import com.trinity.ctc.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/com/trinity/ctc/domain/reservation/repository/ReservationTimeRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/repository/ReservationTimeRepository.java
@@ -1,0 +1,14 @@
+package com.trinity.ctc.domain.reservation.repository;
+
+import com.trinity.ctc.domain.reservation.entity.ReservationTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+@Repository
+public interface ReservationTimeRepository extends JpaRepository<ReservationTime, Long> {
+
+    Optional<ReservationTime> findByTimeSlot(LocalTime timeSlot);
+}

--- a/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
@@ -60,7 +60,7 @@ public class ReservationService {
         log.info("[예약 성공] 예약 ID: {}", reservation.getId());
 
         // DTO 생성
-        return PreoccupyResponse.of(true);
+        return PreoccupyResponse.of(true, reservation.getId());
     }
 
     /**

--- a/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
@@ -1,10 +1,117 @@
 package com.trinity.ctc.domain.reservation.service;
 
+import com.trinity.ctc.domain.reservation.dto.PreoccupyResponse;
+import com.trinity.ctc.domain.reservation.dto.ReservationRequest;
+import com.trinity.ctc.domain.reservation.entity.Reservation;
+import com.trinity.ctc.domain.reservation.entity.ReservationTime;
+import com.trinity.ctc.domain.reservation.repository.ReservationRepository;
+import com.trinity.ctc.domain.reservation.repository.ReservationTimeRepository;
+import com.trinity.ctc.domain.reservation.status.ReservationStatus;
+import com.trinity.ctc.domain.restaurant.entity.Restaurant;
+import com.trinity.ctc.domain.restaurant.entity.repository.RestaurantRepository;
+import com.trinity.ctc.domain.seat.entity.SeatAvailability;
+import com.trinity.ctc.domain.seat.entity.SeatType;
+import com.trinity.ctc.domain.seat.repository.SeatAvailabilityRepository;
+import com.trinity.ctc.domain.seat.repository.SeatTypeRepository;
+import com.trinity.ctc.domain.user.entity.User;
+import com.trinity.ctc.kakao.repository.UserRepository;
+import com.trinity.ctc.util.exception.CustomException;
+import com.trinity.ctc.util.exception.error_code.*;
+import com.trinity.ctc.util.validator.SeatAvailabilityValidator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
+    private final SeatAvailabilityRepository seatAvailabilityRepository;
+    private final UserRepository userRepository;
+    private final RestaurantRepository restaurantRepository;
+    private final SeatTypeRepository seatTypeRepository;
+    private final ReservationTimeRepository reservationTimeRepository;
+    private final ReservationRepository reservationRepository;
 
+    /**
+     * 선점하기
+     * @param reservationRequest
+     * @return 선점성공여부
+     */
+    @Transactional
+    public PreoccupyResponse occupyInAdvance(ReservationRequest reservationRequest) {
+        log.info("[예약 요청] 날짜: {}, 시간: {}, 레스토랑 ID: {}, 사용자 ID: {}, 좌석 타입 ID: {}",
+                reservationRequest.getSelectedDate(), reservationRequest.getReservationTime(),
+                reservationRequest.getRestaurantId(), reservationRequest.getUserId(), reservationRequest.getSeatTypeId());
+
+        // 검증 (좌석 남은 자리 확인)
+        SeatAvailability seatAvailability = validateSeatAvailability(reservationRequest);
+
+        // 좌석 한개 선점
+        log.info("[좌석 선점] 기존 좌석 수: {}", seatAvailability.getAvailableSeats());
+        seatAvailability.preoccupyOneSeat();
+        log.info("[좌석 선점 완료] 남은 좌석 수: {}", seatAvailability.getAvailableSeats());
+
+        // 예약정보 생성 -> 저장
+        Reservation reservation = createReservation(reservationRequest);
+        reservationRepository.save(reservation);
+
+        log.info("[예약 성공] 예약 ID: {}", reservation.getId());
+
+        // DTO 생성
+        return PreoccupyResponse.of(true);
+    }
+
+    /**
+     * 선점가능상태 검증
+     * @param reservationRequest
+     * @return 선점대상 좌석정보
+     */
+    private SeatAvailability validateSeatAvailability(ReservationRequest reservationRequest) {
+        SeatAvailability seatAvailability = seatAvailabilityRepository.findByReservationData(
+                reservationRequest.getRestaurantId(),
+                reservationRequest.getSelectedDate(),
+                reservationRequest.getReservationTime(),
+                reservationRequest.getSeatTypeId()
+        );
+
+        if (!SeatAvailabilityValidator.checkAvailability(seatAvailability)) {
+            log.warn("[예약 실패] 좌석 부족 - 레스토랑 ID: {}, 날짜: {}, 시간: {}, 좌석 타입 ID: {}",
+                    reservationRequest.getRestaurantId(), reservationRequest.getSelectedDate(),
+                    reservationRequest.getReservationTime(), reservationRequest.getSeatTypeId());
+            throw new CustomException(SeatErrorCode.NO_AVAILABLE_SEAT);
+        }
+
+        log.info("[좌석 확인 완료] 남은 좌석 수: {}", seatAvailability.getAvailableSeats());
+        return seatAvailability;
+    }
+
+    /**
+     * 예약정보 생성
+     * @param reservationRequest
+     * @return 예약정보
+     */
+    private Reservation createReservation(ReservationRequest reservationRequest) {
+        User user = userRepository.findById(reservationRequest.getUserId())
+                .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
+
+        Restaurant restaurant = restaurantRepository.findById(reservationRequest.getRestaurantId())
+                .orElseThrow(() -> new CustomException(RestaurantErrorCode.NOT_FOUND));
+
+        SeatType seatType = seatTypeRepository.findById(reservationRequest.getSeatTypeId())
+                .orElseThrow(() -> new CustomException(SeatTypeErrorCode.NOT_FOUND));
+
+        ReservationTime reservationTime = reservationTimeRepository.findByTimeSlot(reservationRequest.getReservationTime())
+                .orElseThrow(() -> new CustomException(ReservationTimeErrorCode.NOT_FOUND));
+
+        return Reservation.builder()
+                .reservationDate(reservationRequest.getSelectedDate())
+                .status(ReservationStatus.IN_PROGRESS)
+                .restaurant(restaurant)
+                .user(user)
+                .reservationTime(reservationTime)
+                .seatType(seatType)
+                .build();
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/restaurant/entity/repository/RestaurantRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/restaurant/entity/repository/RestaurantRepository.java
@@ -1,0 +1,9 @@
+package com.trinity.ctc.domain.restaurant.entity.repository;
+
+import com.trinity.ctc.domain.restaurant.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/com/trinity/ctc/domain/seat/entity/SeatAvailability.java
+++ b/src/main/java/com/trinity/ctc/domain/seat/entity/SeatAvailability.java
@@ -2,6 +2,7 @@ package com.trinity.ctc.domain.seat.entity;
 
 import com.trinity.ctc.domain.reservation.entity.ReservationTime;
 import com.trinity.ctc.domain.restaurant.entity.Restaurant;
+import com.trinity.ctc.util.validator.CapacityValidator;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -30,4 +31,10 @@ public class SeatAvailability {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seat_type_id")
     private SeatType seatType;
+
+    /* 내부 로직 */
+    public void preoccupyOneSeat() {
+        CapacityValidator.validateAvailableSeats(this.availableSeats);
+        availableSeats--;
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/seat/repository/SeatAvailabilityRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/seat/repository/SeatAvailabilityRepository.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface SeatAvailabilityRepository extends JpaRepository<SeatAvailability, Long> {
@@ -26,4 +25,14 @@ public interface SeatAvailabilityRepository extends JpaRepository<SeatAvailabili
             "AND sa.reservationDate = :selectedDate")
     List<SeatAvailability> findAvailableSeatsForDate(@Param("restaurantId") Long restaurantId,
                                                      @Param("selectedDate") LocalDate selectedDate);
+
+    @Query("SELECT sa FROM SeatAvailability sa " +
+            "WHERE sa.restaurant.id = :restaurantId " +
+            "AND sa.reservationDate = :selectedDate " +
+            "AND sa.reservationTime.timeSlot = :reservationTime " +
+            "AND sa.seatType.id = :seatTypeId" )
+    SeatAvailability findByReservationData(@Param("restaurantId") Long restaurantId,
+                                           @Param("selectedDate") LocalDate selectedDate,
+                                           @Param("reservationTime") LocalTime reservationTime,
+                                           @Param("seatTypeId") Long seatTypeId);
 }

--- a/src/main/java/com/trinity/ctc/domain/seat/repository/SeatTypeRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/seat/repository/SeatTypeRepository.java
@@ -1,0 +1,9 @@
+package com.trinity.ctc.domain.seat.repository;
+
+import com.trinity.ctc.domain.seat.entity.SeatType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeatTypeRepository extends JpaRepository<SeatType, Long> {
+}

--- a/src/main/java/com/trinity/ctc/domain/user/entity/User.java
+++ b/src/main/java/com/trinity/ctc/domain/user/entity/User.java
@@ -9,14 +9,17 @@ import com.trinity.ctc.domain.search.entity.SearchHistory;
 import com.trinity.ctc.domain.user.status.Sex;
 import com.trinity.ctc.domain.user.status.UserStatus;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id
@@ -32,6 +35,8 @@ public class User {
     private String phoneNumber;
     private Integer normalTicketCount;
     private Integer emptyTicketCount;
+
+    @Enumerated(EnumType.STRING)
     private Sex sex;
     private String imageUrl;
     private Boolean isDeleted;

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/ReservationTimeErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/ReservationTimeErrorCode.java
@@ -1,0 +1,15 @@
+package com.trinity.ctc.util.exception.error_code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReservationTimeErrorCode implements ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약시간을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/RestaurantErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/RestaurantErrorCode.java
@@ -1,0 +1,15 @@
+package com.trinity.ctc.util.exception.error_code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RestaurantErrorCode implements ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "삭당을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/SeatErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/SeatErrorCode.java
@@ -10,7 +10,8 @@ public enum SeatErrorCode implements ErrorCode {
 
     TIMESLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "타임슬롯을 가져오지 못했습니다. DB를 확인하세요."),
     CAPACITY_IS_NEGATIVE(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "최소 인원수는 0보다 작을 수 없습니다."),
-    BIGGER_MIN_CAPACITY(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "최소 인원수는 최대 인원수보다 클 수 없습니다.");
+    BIGGER_MIN_CAPACITY(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "최소 인원수는 최대 인원수보다 클 수 없습니다."),
+    NO_AVAILABLE_SEAT(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "예약가능 좌석이 0개입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/SeatTypeErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/SeatTypeErrorCode.java
@@ -1,0 +1,15 @@
+package com.trinity.ctc.util.exception.error_code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatTypeErrorCode implements ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "해당 좌석타입을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/trinity/ctc/util/validator/CapacityValidator.java
+++ b/src/main/java/com/trinity/ctc/util/validator/CapacityValidator.java
@@ -15,4 +15,12 @@ public class CapacityValidator {
             throw new CustomException(SeatErrorCode.BIGGER_MIN_CAPACITY);
         }
     }
+
+    public static void validateAvailableSeats(int availableSeats) {
+        if (availableSeats < 0) {
+            throw new CustomException(SeatErrorCode.CAPACITY_IS_NEGATIVE);
+        } else if (availableSeats == 0) {
+            throw new CustomException(SeatErrorCode.NO_AVAILABLE_SEAT);
+        }
+    }
 }

--- a/src/main/java/com/trinity/ctc/util/validator/SeatAvailabilityValidator.java
+++ b/src/main/java/com/trinity/ctc/util/validator/SeatAvailabilityValidator.java
@@ -17,6 +17,10 @@ public class SeatAvailabilityValidator {
                 .anyMatch(sa -> SeatAvailabilityValidator.validate(sa, isToday));
     }
 
+    public static boolean checkAvailability(SeatAvailability seatAvailability) {
+        return seatAvailability.getAvailableSeats() > 0;
+    }
+
     private static boolean checkAvailabilityForToday(SeatAvailability seatAvailability) {
         LocalTime oneHourLater = LocalTime.now().plusHours(1);
         return seatAvailability.getAvailableSeats() > 0 &&


### PR DESCRIPTION
# ☝️Issue Number

- #12 

# 🔎 Key Changes
- 선점 시, 예약대상 좌석 > 0 인지 검증
- 좌석 -1
- 선점상태의 예약정보 생성

# 💌 To Reviewers
- User 엔티티 변동사항
  - 기본 생성자 추가
  - 성별 Enum 타입 명시
- Reservation Created_at -> CreatedAt으로 변경 있습니다.
- Swagger에 그룹 추가할 때, application.yml에 경로 추가하지 않으셔도 됩니다. 
  - 현재 하드코딩해서 url 넣는 방식으로 되어 있습니다.

- 엔티티 수정 사항 적용하고 싶으시면 아래 SQL을 날리시고 다시 하시면 됩니다.

```sql
DROP DATABASE ctc;
CREATE DATABASE ctc;
```
