### PR TITLE
Tri 70 cancel preoccupied reservation

### DIFF
--- a/src/main/java/com/trinity/ctc/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/controller/ReservationController.java
@@ -57,4 +57,22 @@ public class ReservationController {
 
         return ResponseEntity.ok(result);
     }
+
+    @PostMapping("/preoccupy/cancel")
+    @Operation(
+            summary = "예약선점 취소 기능",
+            description = "결제 창에서 타임아웃 또는 뒤로가기 시, 예약상태가 CANCELED로 변경"
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "예약선점 취소 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ReservationResultResponse.class)
+            )
+    )
+    public ResponseEntity<ReservationResultResponse> cancelPreoccupy(@RequestParam long reservationId, @RequestParam long userId) {
+        ReservationResultResponse result = reservationService.cancelPreoccupy(reservationId, userId);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/entity/Reservation.java
@@ -65,4 +65,8 @@ public class Reservation {
     public void completeReservation() {
         this.status = ReservationStatus.COMPLETED;
     }
+
+    public void cancelReservation() {
+        this.status = ReservationStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
@@ -84,6 +84,24 @@ public class ReservationService {
         return ReservationResultResponse.of(true, reservationId, reservation.getRestaurant().getName(), reservation.getReservationDate(), reservation.getReservationTime().getTimeSlot());
     }
 
+    @Transactional
+    public ReservationResultResponse cancelPreoccupy(long reservationId, long userId) {
+        log.info("[예약 정보] 예약정보 ID: {}, 예약자 ID: {}", reservationId, userId);
+
+        // 예약정보 가져오기
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new CustomException(ReservationErrorCode.NOT_FOUND));
+
+        // 예약정보 선점여부 검증
+        ReservationValidator.isPreoccupied(reservation.getStatus());
+
+        // 예약정보 취소 상태로 변경
+        reservation.cancelReservation();
+
+        // 결과 반환
+        return ReservationResultResponse.of(true, reservationId, reservation.getRestaurant().getName(), reservation.getReservationDate(), reservation.getReservationTime().getTimeSlot());
+    }
+
     /**
      * 선점가능상태 검증
      * @param reservationRequest

--- a/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
@@ -98,6 +98,12 @@ public class ReservationService {
         // 예약정보 취소 상태로 변경
         reservation.cancelReservation();
 
+        // 가용좌석 증가 (더티체킹)
+        SeatAvailability seatAvailability = seatAvailabilityRepository.findByReservationData(reservation.getRestaurant().getId(), reservation.getReservationDate(), reservation.getReservationTime().getTimeSlot(), reservation.getSeatType().getId());
+        log.info("[예약 취소 전] 가용좌석 수: {}", seatAvailability.getAvailableSeats());
+        seatAvailability.cancelOneReservation();
+        log.info("[예약 취소 후] 가용좌석 수: {}", seatAvailability.getAvailableSeats());
+
         // 결과 반환
         return ReservationResultResponse.of(true, reservationId, reservation.getRestaurant().getName(), reservation.getReservationDate(), reservation.getReservationTime().getTimeSlot());
     }

--- a/src/main/java/com/trinity/ctc/domain/seat/entity/SeatAvailability.java
+++ b/src/main/java/com/trinity/ctc/domain/seat/entity/SeatAvailability.java
@@ -37,4 +37,9 @@ public class SeatAvailability {
         CapacityValidator.validateAvailableSeats(this.availableSeats);
         availableSeats--;
     }
+
+    public void cancelOneReservation() {
+        CapacityValidator.validateAvailableSeats(this.availableSeats);
+        availableSeats++;
+    }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #18 

# 🔎 Key Changes
- **예약선점 취소 로직 구현**
  - 선점 상태 검증
  - 선점 상태라면 상태변경 (In_PORGRESS -> CANCELED)
  - 가용좌석 +1

# 💌 To Reviewers
- 팀장님, ReservationService 에 cancelPreoccupy() 입니다.
