### PR TITLE
Tri 108 cancel reservation v2

### DIFF
--- a/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
@@ -90,6 +90,9 @@ public class ReservationService {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new CustomException(ReservationErrorCode.NOT_FOUND));
 
+        // 예약정보의 사용자 검증
+        ReservationValidator.validateReservationUserMatched(reservation.getUser().getId(), userId);
+
         // 예약정보 선점여부 검증
         ReservationValidator.isPreoccupied(reservation.getStatus());
 

--- a/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/service/ReservationService.java
@@ -66,11 +66,6 @@ public class ReservationService {
         seatAvailability.preoccupyOneSeat();
         log.info("[좌석 선점 완료] 남은 좌석 수: {}", seatAvailability.getAvailableSeats());
 
-        // 티켓 차감
-        User user = userRepository.findById(reservationRequest.getUserId())
-                .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
-        user.payNormalTickets();
-
         // 예약정보 생성 -> 저장
         Reservation reservation = createReservation(reservationRequest);
         reservationRepository.save(reservation);
@@ -95,6 +90,11 @@ public class ReservationService {
 
         // 예약정보 선점여부 검증
         ReservationValidator.isPreoccupied(reservation.getStatus());
+
+        // 티켓 차감
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
+        user.payNormalTickets();
 
         // 예약정보 완료상태로 변경
         reservation.completeReservation();

--- a/src/main/java/com/trinity/ctc/domain/reservation/validator/ReservationValidator.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/validator/ReservationValidator.java
@@ -3,7 +3,6 @@ package com.trinity.ctc.domain.reservation.validator;
 import com.trinity.ctc.domain.reservation.dto.ReservationRequest;
 import com.trinity.ctc.domain.reservation.entity.Reservation;
 import com.trinity.ctc.domain.reservation.repository.ReservationRepository;
-import com.trinity.ctc.domain.reservation.service.ReservationService;
 import com.trinity.ctc.domain.reservation.status.ReservationStatus;
 import com.trinity.ctc.util.exception.CustomException;
 import com.trinity.ctc.util.exception.error_code.ReservationErrorCode;
@@ -33,7 +32,7 @@ public class ReservationValidator {
     }
 
     public static boolean checkCOD(LocalDate reservationDate) {
-        return DateTimeValidator.isTwoDaysAgoOrBefore(reservationDate);
+        return DateTimeValidator.isMoreThanOneDayAway(reservationDate);
     }
 
     public void validateUserReservation(ReservationRequest request) {

--- a/src/main/java/com/trinity/ctc/domain/reservation/validator/ReservationValidator.java
+++ b/src/main/java/com/trinity/ctc/domain/reservation/validator/ReservationValidator.java
@@ -19,6 +19,12 @@ public class ReservationValidator {
 
     private final ReservationRepository reservationRepository;
 
+    public static void validateReservationUserMatched(long reservationUserId, long requestUserid) {
+        if (reservationUserId != requestUserid) {
+            throw new CustomException(ReservationErrorCode.RESERVATION_USER_MISMATCH);
+        }
+    }
+
     public static void isPreoccupied(ReservationStatus reservationStatus) {
         if (reservationStatus != ReservationStatus.IN_PROGRESS) {
             throw new CustomException(ReservationErrorCode.NOT_PREOCCUPIED);

--- a/src/main/java/com/trinity/ctc/util/exception/error_code/ReservationErrorCode.java
+++ b/src/main/java/com/trinity/ctc/util/exception/error_code/ReservationErrorCode.java
@@ -16,7 +16,9 @@ public enum ReservationErrorCode implements ErrorCode {
     ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 예약(결제)완료 된 예약입니다."),
     NOT_COMPLETED(HttpStatus.BAD_REQUEST, "예약이 완료상태가 아닙니다."),
 
-    ALREADY_RESERVED_BY_USER(HttpStatus.BAD_REQUEST, "이미 선점, 완료 된 예약입니다.");
+    ALREADY_RESERVED_BY_USER(HttpStatus.BAD_REQUEST, "이미 선점, 완료 된 예약입니다."),
+
+    RESERVATION_USER_MISMATCH(HttpStatus.BAD_REQUEST, "예약자와 요청 사용자가 다릅니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/trinity/ctc/util/validator/DateTimeValidator.java
+++ b/src/main/java/com/trinity/ctc/util/validator/DateTimeValidator.java
@@ -34,8 +34,8 @@ public class DateTimeValidator {
      * @param localDate
      * @return 이틀 전이면 true, 아니면 false
      */
-    public static boolean isTwoDaysAgoOrBefore(LocalDate localDate) {
-        LocalDate twoDaysAgo = LocalDate.now().minusDays(2);
-        return localDate.isBefore(twoDaysAgo) || localDate.isEqual(twoDaysAgo);
+    public static boolean isMoreThanOneDayAway(LocalDate localDate) {
+        LocalDate oneDayAfter = LocalDate.now().plusDays(1);
+        return localDate.isAfter(oneDayAfter) | localDate.isEqual(oneDayAfter);
     }
 }

--- a/src/test/java/com/trinity/ctc/util/DateTimeUtilTest.java
+++ b/src/test/java/com/trinity/ctc/util/DateTimeUtilTest.java
@@ -3,9 +3,11 @@ package com.trinity.ctc.util;
 import com.trinity.ctc.util.formatter.DateTimeUtil;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.trinity.ctc.util.validator.DateTimeValidator.isMoreThanOneDayAway;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DateTimeUtilTest {
 
@@ -35,5 +37,26 @@ public class DateTimeUtilTest {
         LocalDateTime dateTime = LocalDateTime.of(2025, 2, 10, 15, 45, 30);
         LocalDateTime truncatedMinute = DateTimeUtil.truncateToMinute(dateTime);
         assertEquals(LocalDateTime.of(2025, 2, 10, 15, 45), truncatedMinute);
+    }
+
+    @Test
+    void testIsMoreThanOneDaysAway() {
+        /* 테스트 당시 날짜 = 2025-02-22 */
+
+        // 테스트 대상 날짜들
+        LocalDate reservationDate6 = LocalDate.of(2025, 2, 21);
+        LocalDate reservationDate1 = LocalDate.of(2025, 2, 22);
+        LocalDate reservationDate2 = LocalDate.of(2025, 2, 23);
+        LocalDate reservationDate3 = LocalDate.of(2025, 2, 24);
+        LocalDate reservationDate4 = LocalDate.of(2025, 2, 25);
+        LocalDate reservationDate5 = LocalDate.of(2025, 2, 26);
+
+        // 테스트 실행
+        assertFalse(isMoreThanOneDayAway(reservationDate6));
+        assertFalse(isMoreThanOneDayAway(reservationDate1));
+        assertTrue(isMoreThanOneDayAway(reservationDate2));
+        assertTrue(isMoreThanOneDayAway(reservationDate3));
+        assertTrue(isMoreThanOneDayAway(reservationDate4));
+        assertTrue(isMoreThanOneDayAway(reservationDate5));
     }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #48 

# 🔎 Key Changes
- 예약취소 시, 날짜 검증이 반대로 되어 있는 부분 수정
  - 예약일로부터 이틀 후가 아닌 당일인지 여부를 검증하도록 수정.
  - 예약일 00:00 시, 이전만 티켓 반환

- 티켓 차감 시점 변경: 예약선점 -> 예약완료

- 예약완료 기능 호출 시, 요청을 보낸 사용자가 예약자인지 검증하는 로직 추가

# 💌 To Reviewers
- 수정사항이 많았습니다. 죄송합니다!