### PR TITLE
Tri 180 token api fix

### DIFF
--- a/src/main/java/com/trinity/ctc/domain/fcm/dto/FcmTokenRequest.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/dto/FcmTokenRequest.java
@@ -13,9 +13,4 @@ public class FcmTokenRequest {
     @NotNull
     @Schema(description = "FCM 토큰 값", example = "eFWf9agIX28I7RXM3Zy5_G:APA91bGuCc3Do-SZVanV7C39JH465yTDL...")
     private String fcmToken;
-
-//    @Schema(description = "토큰 발급 시간 (optional, yyyy-MM-dd HH:mm 형식의 timeStamp, 로그아웃 요청 시 불필요)",
-//            example = "2024-03-13 13:55")
-//    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
-//    private LocalDateTime timeStamp;
 }

--- a/src/main/java/com/trinity/ctc/domain/fcm/repository/FcmRepository.java
+++ b/src/main/java/com/trinity/ctc/domain/fcm/repository/FcmRepository.java
@@ -14,6 +14,8 @@ import java.util.List;
 @Repository
 public interface FcmRepository extends JpaRepository<Fcm, Long> {
     @Transactional
+    @Modifying
+    @Query("DELETE FROM Fcm f WHERE f.token = :token")
     void deleteByToken(String token);
 
     @Transactional

--- a/src/main/java/com/trinity/ctc/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/trinity/ctc/domain/notification/service/NotificationService.java
@@ -713,8 +713,6 @@ public class NotificationService {
      */
     @Transactional
     public void sendReservationCanceledNotification(Long userId, Long reservationId, boolean isCODPassed) {
-        log.info("asdfadsfasdf");
-
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
         Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new CustomException(ReservationErrorCode.NOT_FOUND));
         FcmMessageDto messageData = formattingReservationCanceledNotification(reservation, user, isCODPassed);

--- a/src/main/java/com/trinity/ctc/domain/user/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/trinity/ctc/domain/user/jwt/CustomLogoutFilter.java
@@ -86,13 +86,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
         // 🚀 로그아웃 처리
         refreshTokenRepository.deleteByRefreshToken(refresh);
 
-        // 🚀 Refresh 토큰 쿠키 제거
-        Cookie cookie = new Cookie("refresh", null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
-
         response.setStatus(HttpServletResponse.SC_OK);
         log.info("✅ Successfully logged out.");
     }

--- a/src/main/java/com/trinity/ctc/domain/user/service/TokenService.java
+++ b/src/main/java/com/trinity/ctc/domain/user/service/TokenService.java
@@ -111,7 +111,7 @@ public class TokenService {
 
         // response
         response.setHeader("access", newAccess);
-        response.addCookie(createCookie("refresh", newRefresh));
+        response.setHeader("refresh", newRefresh);
 
         // 토큰을 굳이 보낼 이유는 없다. 후에 고민
         return newAccess;


### PR DESCRIPTION
# ☝️Issue Number

- #107 

# 🔎 Key Changes
- fcm 토큰 삭제 api 수정
- refresh token 발급 시 header에 담아 response 주도록 수정

# 💌 To Reviewers
- 온보딩 후 response의 header에 재발급 된 access/refresh 토큰으로 다시 세팅해주셔야 됩니다. 
